### PR TITLE
Allow programatical change of state on disabled and readonly

### DIFF
--- a/dist/js/bootstrap-switch.js
+++ b/dist/js/bootstrap-switch.js
@@ -135,9 +135,6 @@
         if (typeof value === "undefined") {
           return this.options.state;
         }
-        if (this.options.disabled || this.options.readonly) {
-          return this.$element;
-        }
         if (this.options.state && !this.options.radioAllOff && this.$element.is(":radio")) {
           return this.$element;
         }
@@ -577,7 +574,9 @@
           return function(event) {
             event.preventDefault();
             event.stopPropagation();
-            _this.state(false);
+            if (!_this.options.disabled && !_this.options.readonly) {
+                _this.state(false);
+            }
             return _this.$element.trigger("focus.bootstrapSwitch");
           };
         })(this));
@@ -585,7 +584,9 @@
           return function(event) {
             event.preventDefault();
             event.stopPropagation();
-            _this.state(true);
+            if (!_this.options.disabled && !_this.options.readonly) {
+                _this.state(true);
+            }
             return _this.$element.trigger("focus.bootstrapSwitch");
           };
         })(this));


### PR DESCRIPTION
The change proposed allows the state to be programatically changed on the state method, for things like when data is changed on the screen.
But still disables the ability to change state of the switch if clicked on screen for disabled or readonly.
