### PR TITLE
allow upward range of jquery versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "dist/js/bootstrap-switch.js",
   "peerDependencies": {
     "bootstrap": "^3.1.1",
-    "jquery": "~1.9.0"
+    "jquery": ">=1.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@LostCrew Sorry for the delayed response, I wanted to verify my words before I responded...what I actually mean is using the `>=` operator as opposed to the `~`. Apologies, I submitted a PR with the change if you agree. 
The benefit is that as long as the siblings require anything jquery 1.9.x and above, you will not throw errors for EPEERINVALID during install. The risk is following edge version of jquery and the consequences therein; however I am assuming you are mostly using basic selectors which shouldn't change.

Thanks for thinking on this. -Jonathan