### PR TITLE
Fix unclickable switch center

### DIFF
--- a/src/js/bootstrap-switch.js
+++ b/src/js/bootstrap-switch.js
@@ -508,7 +508,7 @@ class BootstrapSwitch {
         if (this._dragStart == null) { return }
         const difference = (event.pageX || event.originalEvent.touches[0].pageX) - this._dragStart
         event.preventDefault()
-        if (difference < -this._handleWidth || difference > 0) { return }
+        if (difference <= -this._handleWidth || difference > 0) { return }
         this._dragEnd = difference
         this.$container.css('margin-left', `${this._dragEnd}px`)
       },


### PR DESCRIPTION
This change fixes a long-standing issue with the white portion of the Off switch being not clickable.
Issues reported on it here:
https://github.com/Bttstrp/bootstrap-switch/issues/481
and here:
https://github.com/Bttstrp/bootstrap-switch/issues/628
and here, all the same bug, reported since couple of years
https://github.com/Bttstrp/bootstrap-switch/issues/467

Plunker to demonstrate bug (uses existing code)
https://plnkr.co/edit/wXJvctugqNAx00rgUfeg?p=preview

Plunker to demonstrate fix (uses this fork)
https://plnkr.co/edit/DY1Icvv4HyDi2D0PkfdU?p=preview

When using these Plunkers, set the switch to Off state.  Try clicking on the white part of the switch (the part that doesn't say "Off") - notice that it does not switch off in the first Plunker (with bug) and that it correctly switches off in the second Plunker (with my fix)