### PR TITLE
Added closing bracket to prevent JS compilation error

### DIFF
--- a/src/js/bootstrap-switch.js
+++ b/src/js/bootstrap-switch.js
@@ -612,4 +612,4 @@
     onInit: () => {},
     onSwitchChange: () => {}
   }
-})(window.jQuery, window)
+})(window.jQuery, window);


### PR DESCRIPTION
There is a missing semicolon at the end of the file, which causes it to break other scripts if being included and merged in with other files. I've added the closing semi colon to prevent JS compilation error.