### PR TITLE
Changed Required jQuery Version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
   ],
   "dependencies": {
     "bootstrap": ">=2.3.2",
-    "jquery": "~1.9.0"
+    "jquery": ">=1.9.0"
   }
 }


### PR DESCRIPTION
The bower.json file should require a >=1.9.0 instead of being locked
into 1.9.x.  This was changed back to the way it was in 3.3.3.