### PR TITLE
Fix typo. Fixes #683

### DIFF
--- a/src/js/bootstrap-switch.js
+++ b/src/js/bootstrap-switch.js
@@ -58,7 +58,7 @@ function prvwidth() {
   return this.$wrapper.width(this.privateHandleWidth + this.privateLabelWidth);
 }
 
-function prvcontainerPosition(state = this.ope) {
+function prvcontainerPosition(state = this.options.state) {
   this.$container.css('margin-left', () => {
     const values = [0, `-${this.privateHandleWidth}px`];
     if (this.options.indeterminate) {


### PR DESCRIPTION
Apparently, this typo leads to a bug with the select button - it is ON, but displayed as OFF, because it is unable to iterate through the classes that muse be set