### PR TITLE
Use Array.isArray instead of $.isArray

### DIFF
--- a/src/js/bootstrap-switch.js
+++ b/src/js/bootstrap-switch.js
@@ -265,7 +265,7 @@ function prvformHandler() {
 }
 
 function prvgetClasses(classes) {
-  if (!$.isArray(classes)) {
+  if (!Array.isArray(classes)) {
     return [this::prvgetClass(classes)];
   }
   return classes.map(v => this::prvgetClass(v));


### PR DESCRIPTION
Changed `$.isArray` for `Array.isArray` as the former is deprecated and the latter [is implemented in all the browsers](https://caniuse.com/#feat=mdn-javascript_builtins_array_isarray) supported by Bootstrap Switch.

Fixes #724 
